### PR TITLE
chore: add .dockerignore to reduce build context size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+node_modules
+dist
+*.log
+.env
+.env.*
+!.env.example
+.DS_Store
+coverage
+.nyc_output


### PR DESCRIPTION
The Dockerfile uses COPY . . which sends .git, node_modules, dist, and other unnecessary files to the Docker daemon. Adding a .dockerignore with sensible defaults for a Node.js/TypeScript monorepo to speed up builds and reduce image size.