### PR TITLE
fix: bump Dockerfile to Node 22 and correct exposed port to 8081

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:16-alpine
+FROM node:22-alpine
 WORKDIR /app
 
 COPY . .
 RUN npm ci
 RUN npm run build
 
-EXPOSE 8080
+EXPOSE 8081
 ENV NODE_ENV=production
 
 CMD ["./cmd.sh"]


### PR DESCRIPTION
Node 16 is EOL. Upgrade base image to node:22-alpine (current LTS). The app defaults to port 8081 (per run.ts and docker-compose.yaml), so update EXPOSE from 8080 to 8081 to match.