### PR TITLE
fix: use multi-stage Docker build to halve image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,18 +4,34 @@ WORKDIR /app
 COPY . .
 RUN npm ci
 RUN npm run build
-
-# Remove devDependencies after build
 RUN npm prune --omit=dev
 
 FROM node:22-alpine
 WORKDIR /app
 
-# Copy only production node_modules and built output
-COPY --from=build /app/node_modules ./node_modules
-COPY --from=build /app/packages ./packages
 COPY --from=build /app/package.json ./package.json
+COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/cmd.sh ./cmd.sh
+
+# Copy only built output and package metadata from each package
+COPY --from=build /app/packages/aleph-credit/dist ./packages/aleph-credit/dist
+COPY --from=build /app/packages/aleph-credit/package.json ./packages/aleph-credit/package.json
+COPY --from=build /app/packages/aleph-holders/dist ./packages/aleph-holders/dist
+COPY --from=build /app/packages/aleph-holders/package.json ./packages/aleph-holders/package.json
+COPY --from=build /app/packages/aleph-messages/dist ./packages/aleph-messages/dist
+COPY --from=build /app/packages/aleph-messages/package.json ./packages/aleph-messages/package.json
+COPY --from=build /app/packages/aleph-vouchers/dist ./packages/aleph-vouchers/dist
+COPY --from=build /app/packages/aleph-vouchers/package.json ./packages/aleph-vouchers/package.json
+COPY --from=build /app/packages/indexer-generator/dist ./packages/indexer-generator/dist
+COPY --from=build /app/packages/indexer-generator/package.json ./packages/indexer-generator/package.json
+COPY --from=build /app/packages/marinade-finance/dist ./packages/marinade-finance/dist
+COPY --from=build /app/packages/marinade-finance/package.json ./packages/marinade-finance/package.json
+COPY --from=build /app/packages/spl-lending/dist ./packages/spl-lending/dist
+COPY --from=build /app/packages/spl-lending/package.json ./packages/spl-lending/package.json
+COPY --from=build /app/packages/spl-token/dist ./packages/spl-token/dist
+COPY --from=build /app/packages/spl-token/package.json ./packages/spl-token/package.json
+COPY --from=build /app/packages/token/dist ./packages/token/dist
+COPY --from=build /app/packages/token/package.json ./packages/token/package.json
 
 EXPOSE 8081
 ENV NODE_ENV=production

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,21 @@
-FROM node:22-alpine
+FROM node:22-alpine AS build
 WORKDIR /app
 
 COPY . .
 RUN npm ci
 RUN npm run build
+
+# Remove devDependencies after build
+RUN npm prune --omit=dev
+
+FROM node:22-alpine
+WORKDIR /app
+
+# Copy only production node_modules and built output
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/packages ./packages
+COPY --from=build /app/package.json ./package.json
+COPY --from=build /app/cmd.sh ./cmd.sh
 
 EXPOSE 8081
 ENV NODE_ENV=production

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,32 +6,21 @@ RUN npm ci
 RUN npm run build
 RUN npm prune --omit=dev
 
+# Assemble only runtime artifacts
+RUN mkdir /runtime && \
+    cp package.json cmd.sh /runtime/ && \
+    cp -r node_modules /runtime/node_modules && \
+    for pkg in packages/*/; do \
+      name=$(basename "$pkg") && \
+      mkdir -p "/runtime/packages/$name" && \
+      cp -r "$pkg/dist" "/runtime/packages/$name/dist" && \
+      cp "$pkg/package.json" "/runtime/packages/$name/package.json" \
+    ; done
+
 FROM node:22-alpine
 WORKDIR /app
 
-COPY --from=build /app/package.json ./package.json
-COPY --from=build /app/node_modules ./node_modules
-COPY --from=build /app/cmd.sh ./cmd.sh
-
-# Copy only built output and package metadata from each package
-COPY --from=build /app/packages/aleph-credit/dist ./packages/aleph-credit/dist
-COPY --from=build /app/packages/aleph-credit/package.json ./packages/aleph-credit/package.json
-COPY --from=build /app/packages/aleph-holders/dist ./packages/aleph-holders/dist
-COPY --from=build /app/packages/aleph-holders/package.json ./packages/aleph-holders/package.json
-COPY --from=build /app/packages/aleph-messages/dist ./packages/aleph-messages/dist
-COPY --from=build /app/packages/aleph-messages/package.json ./packages/aleph-messages/package.json
-COPY --from=build /app/packages/aleph-vouchers/dist ./packages/aleph-vouchers/dist
-COPY --from=build /app/packages/aleph-vouchers/package.json ./packages/aleph-vouchers/package.json
-COPY --from=build /app/packages/indexer-generator/dist ./packages/indexer-generator/dist
-COPY --from=build /app/packages/indexer-generator/package.json ./packages/indexer-generator/package.json
-COPY --from=build /app/packages/marinade-finance/dist ./packages/marinade-finance/dist
-COPY --from=build /app/packages/marinade-finance/package.json ./packages/marinade-finance/package.json
-COPY --from=build /app/packages/spl-lending/dist ./packages/spl-lending/dist
-COPY --from=build /app/packages/spl-lending/package.json ./packages/spl-lending/package.json
-COPY --from=build /app/packages/spl-token/dist ./packages/spl-token/dist
-COPY --from=build /app/packages/spl-token/package.json ./packages/spl-token/package.json
-COPY --from=build /app/packages/token/dist ./packages/token/dist
-COPY --from=build /app/packages/token/package.json ./packages/token/package.json
+COPY --from=build /runtime .
 
 EXPOSE 8081
 ENV NODE_ENV=production


### PR DESCRIPTION
Separate build stage from runtime stage so devDependencies, source files, and build tooling are not shipped in the final image.